### PR TITLE
Make it possible to override timeouts

### DIFF
--- a/src/capacitor/core.clj
+++ b/src/capacitor/core.clj
@@ -25,7 +25,9 @@
       :port         (default: 8086)
       :username     (default \"root\")
       :password     (default \"root\")
-      :db           (default: \"default-db\")"
+      :db           (default: \"default-db\")
+      :post-opts    (http post options, default: \"nil\")
+      :get-opts     (http get options, default: \"nil\")"
   [opts]
   (merge default-client opts))
 
@@ -440,12 +442,13 @@
     (let [url  (gen-url client { :action         :post-points
                                  :time-precision time-precision })
           body (json/generate-string points)]
-      (http-client/post url {
+      (http-client/post url (merge {
         :body                  body
         :socket-timeout        1000 ;; in milliseconds
         :conn-timeout          1000 ;; in milliseconds
         :content-type          :json
-        :throw-entire-message? true }))))
+        :throw-entire-message? true }
+        (:post-opts client))))))
 
 (defn format-payload
   [res]
@@ -508,11 +511,12 @@
     (let [url (str (gen-url client {:action         :get-query
                                     :time-precision time-precision})
                                    (URLEncoder/encode query))]
-      (http-client/get url {
+      (http-client/get url (merge {
         :socket-timeout        10000  ;; in milliseconds
         :conn-timeout          10000  ;; in milliseconds
         :accept                :json
-        :throw-entire-message? true }))))
+        :throw-entire-message? true }
+        (:get-opts client))))))
 
 (defn format-series-results
   {:no-doc true}


### PR DESCRIPTION
Hi guys,

I propose the inclusion of the following change: merge :post-opts / :get-opts client parameter in post-points / get-query so that the socket and connection timeouts can be overridden.

I'm using some Fanout Continuous Queries within my InfluxDB server, so it seems the writes are a bit slower, which makes call to post-points timeouts. This PR makes it possible to override the read timeout by using a specific client property:

```
(def client (influx/make-client {:db "test_db"
                                 :post-opts {:socket-timeout 10000}
                                 :get-opts {:socket-timeout 2000}}))
```

Let my know what you think of this change.
