### PR TITLE
Keywordize admin get queries

### DIFF
--- a/src/capacitor/core.clj
+++ b/src/capacitor/core.clj
@@ -153,7 +153,7 @@
 (defn get-dbs
   "Returns vector of database names."
   [client]
-  (json/parse-string ((get-dbs-req client) :body)))
+  (json/parse-string ((get-dbs-req client) :body) true))
 
 ;;;;;;;;;;;;;;;;;;;;;;
 ;; ### Drop a database
@@ -232,7 +232,7 @@
 (defn get-admin-users
   "List admin users"
   [client]
-  (json/parse-string ((get-admin-users-req client) :body)))
+  (json/parse-string ((get-admin-users-req client) :body) true))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; #### Update admin user
@@ -311,7 +311,7 @@
 (defn get-db-users
   "List database users"
   [client]
-  (json/parse-string ((get-db-users-req client) :body)))
+  (json/parse-string ((get-db-users-req client) :body) true))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; #### Update database user
@@ -370,7 +370,7 @@
 (defn get-shards
   "List shards."
   [client]
-  (json/parse-string ((get-shards-req client) :body)))
+  (json/parse-string ((get-shards-req client) :body) true))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; #### Get all shard spaces
@@ -387,7 +387,7 @@
 (defn get-shard-spaces
   "List shard spaces."
   [client]
-  (json/parse-string ((get-shard-spaces-req client) :body)))
+  (json/parse-string ((get-shard-spaces-req client) :body) true))
 
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;


### PR DESCRIPTION
When parsing the JSON of admin get queries result, this transform the map keys to keywords. This makes the result map easier to use IMHO.

I haven't enabled this transformation in `get-query` as it has a cost on performance. This is almost unnoticeable on admin queries, but probably not on queries that returns a lot of records from InfluxDB.
