### PR TITLE
async/enqueue: reuse existing :time entry if set by the client

### DIFF
--- a/src/capacitor/async.clj
+++ b/src/capacitor/async.clj
@@ -56,9 +56,9 @@
 
 (defn enqueue
   "Append event to `e-in` channel.
-  The `:time` attribute (in ms) is automatically added when the event is added."
+  The `:time` attribute (in ms) is automatically added when the event is added and no existing attribute is found."
   [e-in event]
-  (let [ts (System/currentTimeMillis)]
+  (let [ts (or (:time event) (System/currentTimeMillis))]
     (put! e-in (merge { :time ts } event))))
 
 (defn post-points-req


### PR DESCRIPTION
Here is a small change to allow reuse of existing :time property if already defined in the event. It is already working, this change only prevent a call to `System/currentTimeMillis` in that case. And the function doc is made more clear about it.
