### PR TITLE
Redo changes in #11, removed by #12

### DIFF
--- a/src/capacitor/core.clj
+++ b/src/capacitor/core.clj
@@ -25,7 +25,9 @@
       :port         (default: 8086)
       :username     (default \"root\")
       :password     (default \"root\")
-      :db           (default: \"default-db\")"
+      :db           (default: \"default-db\")
+      :post-opts    (http post options, default: \"nil\")
+      :get-opts     (http get options, default: \"nil\")"
   [opts]
   (merge default-client opts))
 
@@ -439,12 +441,13 @@
     (let [url  (gen-url client { :action         :post-points
                                  :time-precision time-precision })
           body (json/generate-string points)]
-      (http-client/post url {
+      (http-client/post url (merge {
         :body                  body
         :socket-timeout        1000 ;; in milliseconds
         :conn-timeout          1000 ;; in milliseconds
         :content-type          :json
-        :throw-entire-message? true }))))
+        :throw-entire-message? true }
+        (:post-opts client))))))
 
 (defn format-payload
   [res]
@@ -507,11 +510,12 @@
     (let [url (str (gen-url client {:action         :get-query
                                     :time-precision time-precision})
                                    (URLEncoder/encode query))]
-      (http-client/get url {
+      (http-client/get url (merge {
         :socket-timeout        10000  ;; in milliseconds
         :conn-timeout          10000  ;; in milliseconds
         :accept                :json
-        :throw-entire-message? true }))))
+        :throw-entire-message? true }
+        (:get-opts client))))))
 
 (defn format-series-results
   {:no-doc true}


### PR DESCRIPTION
Sorry, I did a mess in git which removed the changes to have configurable timeouts.

While working on #12, I accidentally merged the branch configurable-timeout. So I reverted commit de4661e28d031e4de6361e5ab474112df984eb5e, and this removed the configurable timeouts code from master! So it's not part of release 0.3.1 :-(
