### PR TITLE
core.async upgrade, configurable async timeouts & logging

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -5,11 +5,12 @@
     :name "Eclipse Public License"
     :url  "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [
-    [org.clojure/clojure    "1.5.1"]
-    [org.clojure/core.async "0.1.319.0-6b1aca-alpha"]
-    [clj-http               "0.9.1"]
-    [http-kit               "2.1.18"]
-    [cheshire               "5.3.1"]
+    [org.clojure/clojure       "1.5.1"]
+    [org.clojure/core.async    "0.1.319.0-6b1aca-alpha"]
+    [clj-http                  "0.9.1"]
+    [http-kit                  "2.1.18"]
+    [cheshire                  "5.3.1"]
+    [org.clojure/tools.logging "0.3.1"]
   ]
   :plugins [
     [codox           "0.6.6"]

--- a/project.clj
+++ b/project.clj
@@ -6,7 +6,7 @@
     :url  "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [
     [org.clojure/clojure    "1.5.1"]
-    [org.clojure/core.async "0.1.267.0-0d7780-alpha"]
+    [org.clojure/core.async "0.1.319.0-6b1aca-alpha"]
     [clj-http               "0.9.1"]
     [http-kit               "2.1.18"]
     [cheshire               "5.3.1"]

--- a/src/capacitor/async.clj
+++ b/src/capacitor/async.clj
@@ -3,6 +3,7 @@
     [capacitor.accumulator :as acc]
     [org.httpkit.client :as http-client]
     [cheshire.core      :as json]
+    [clojure.tools.logging :as log]
     [clojure.core.async :refer [chan
                                 sliding-buffer
                                 go
@@ -64,18 +65,24 @@
 (defn post-points-req
   [client points]
   (let [url  (gen-url client :post-points)
-        body (json/generate-string points)]
-    (http-client/post url {
-      :body                  body
-      ;;:socket-timeout        1000 ;; in milliseconds
-      ;;:conn-timeout          1000 ;; in milliseconds
-      :content-type          :json
-      :throw-entire-message? true })))
+        body (json/generate-string points)
+        opts (merge {:body                  body
+                     ;;:timeout             60000 ;; in milliseconds
+                     :content-type          :json
+                     :throw-entire-message? true}
+                    (:async-post-opts client))]
+    (http-client/post url opts
+                      (fn [{:keys [status error]}] ;; asynchronous response handling
+                        (if error
+                          (log/warnf error "Failed to post %d point(s), received status %s" (count points) status)
+                          (log/debugf "async http post: %s" status))))))
 
 (defn post-points
   "Post points to database. Returns HTTP response.
   Points should be submitted as a vector of maps."
   [client values]
+  (if (log/enabled? :debug)
+    (log/debugf "Posting %d value(s): %s" (count values) values))
   (post-points-req client (make-payload values)))
 
 ;;
@@ -105,11 +112,12 @@
   [client query]
   (let [url   (str (gen-url client :get-query) (URLEncoder/encode query))
         c-out (chan)]
-    (http-client/get url {
+    (http-client/get url (merge {
       :socket-timeout        60000  ;; in milliseconds
       :conn-timeout          60000  ;; in milliseconds
       :accept                :json
       :throw-entire-message? true }
+      (:async-get-opts client))
       (fn [r]
         (put! c-out r)))
     c-out))


### PR DESCRIPTION
Hi guys,

Here is another change I suggest for inclusion within capacitor. With this change, it is now possible to override the default get and post options, specifically, by defining a ```:timeout``` property within the client, inside either ```async-get-opts``` or ```async-post-opts```. The property differ from the synchronous client as httpkit does not accept the same parameters than clj-http.

I've also added a bit of logging around post-points. It will now log at warning level when some points couldn't be added to InfluxDB. There is also a debug log that will log the number of points that will be posted. Might be useful to diagnose problems.

I've also upgraded the core.async version to the latest one available for clojure 1.5.1 (the more recent versions requires clojure 1.6.0).

Let me know what you think of all my changes.

Thanks,
Reynald
