### PR TITLE
New ping command to get cluster status

### DIFF
--- a/src/capacitor/core.clj
+++ b/src/capacitor/core.clj
@@ -45,7 +45,14 @@
     ":"
     (client :port)
     (cond (contains? #{:ping} (action :action))
-          "/ping"
+          (str "/" (-> action :action name))
+          (contains? #{:sync} (action :action))
+          (str "/"
+               (-> action :action name)
+               "?u="
+               (client :username)
+               "&p="
+               (client :password))
           (contains? #{ :create-admin-user
                         :delete-admin-user
                         :update-admin-user
@@ -122,6 +129,10 @@
   [string]
   (json/parse-string string true))
 
+;;
+;; ## Database status
+;;
+
 (defn ping
   [client]
   (-> client
@@ -134,6 +145,19 @@
                (:get-opts client)))
       :body
       kw-parse-string))
+
+(defn sync?
+  [client]
+  (-> client
+      (gen-url :sync)
+      (http-client/get 
+        (merge {:socket-timeout       1000
+                :conn-timeout         1000
+                :accept               :json
+                :trow-entire-message? true}
+               (:get-opts client)))
+      :body
+      Boolean/parseBoolean))
 
 ;;
 ;; ## Database management

--- a/test/capacitor/core_test.clj
+++ b/test/capacitor/core_test.clj
@@ -145,6 +145,16 @@
            (gen-url (make-client {:db "my-db"
                                   :shard-id 1}) :drop-shard)))))
 
+(deftest test-gen-url-18
+  (testing "ping"
+    (is (= "http://localhost:8086/ping"
+           (gen-url (make-client {}) :ping)))))
+
+(deftest test-gen-url-19
+  (testing "sync"
+    (is (= "http://localhost:8086/sync?u=root&p=root"
+           (gen-url (make-client {}) :sync)))))
+
 (deftest test-format-results-00
   (testing "format-results"
     (is (= [


### PR DESCRIPTION
Here is an additional command added, to get the cluster status. Could be useful in client code to monitor if InfluxDB is still alive, and do proper actions if not.

Let me know what's your opinion on this addition.
