### PR TITLE
New list-series function

### DIFF
--- a/src/capacitor/core.clj
+++ b/src/capacitor/core.clj
@@ -615,3 +615,16 @@
     (read-result (get-query-req client query)))
   ([client time-precision query]
     (read-result (get-query-req client time-precision query))))
+
+(defn list-series
+  "List all series in the current client database or in the specified database."
+  ([{:keys [db] :as client}]
+    (list-series client db))
+  ([client database]
+    (->> "list series"
+         (get-query-req (merge client {:db database}))
+         :body
+         (#(json/parse-string % true))
+         first
+         :points
+         (map second))))


### PR DESCRIPTION
Here is another function to execute the "list series" query.

Using (get-query "list series") doesn't work as the returned format seems to be different than any other query, and I don't want to mess with the format-series-results function.

Let me know your thoughts about this one.