### PR TITLE
Bump core.async version

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -6,7 +6,7 @@
     :url  "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [
     [org.clojure/clojure    "1.5.1"]
-    [org.clojure/core.async "0.1.267.0-0d7780-alpha"]
+    [org.clojure/core.async "0.1.319.0-6b1aca-alpha"]
     [clj-http               "0.9.1"]
     [http-kit               "2.1.18"]
     [cheshire               "5.3.1"]]


### PR DESCRIPTION
Use the most recent version compatible with Clojure 1.5.1.

Split from https://github.com/olauzon/capacitor/pull/17