### PR TITLE
Add logging inside post-points

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -9,7 +9,8 @@
     [org.clojure/core.async "0.1.267.0-0d7780-alpha"]
     [clj-http               "0.9.1"]
     [http-kit               "2.1.18"]
-    [cheshire               "5.3.1"]]
+    [cheshire               "5.3.1"]
+    [org.clojure/tools.logging "0.3.1"]]
   :plugins [
     [codox           "0.6.6"]
     [lein-marginalia "0.7.1"]]


### PR DESCRIPTION
Whenever the asynchronous post-points calls fails, log a warning message with the number of points that are not recorded inside InfluxDB.

Split from #17 . I'll wait on this one to be merged before adding the async timeouts config options as there will be merge conflicts if I already do a PR.
