### PR TITLE
Added version command to get influxdb version.

### DIFF
--- a/src/capacitor/core.clj
+++ b/src/capacitor/core.clj
@@ -1,4 +1,5 @@
 (ns capacitor.core
+  (:use [clojure.string :only [split]])
   (:require [clj-http.client :as http-client]
             [clojure.set :as set]
             [cheshire.core   :as json])
@@ -148,6 +149,25 @@
                (:get-opts client)))
       :body
       kw-parse-string))
+
+;;
+;; ## InfluxDB Version
+;;
+
+(defn version
+  [client]
+  (-> (-> client
+        (gen-url :ping)
+        (http-client/get
+          (merge {:socket-timeout        10000
+                  :conn-timeout          10000
+                  :accept                :json
+                  :throw-entire-message? true}
+                  (:get-opts client))))
+      (:headers)
+      (get "x-influxdb-version")
+      (split #"\s")
+      (second)))
 
 (defn sync?
   [client]

--- a/src/capacitor/core.clj
+++ b/src/capacitor/core.clj
@@ -154,6 +154,10 @@
 ;; ## InfluxDB Version
 ;;
 
+(defn get-version
+  [array]
+  (if (= (count array) 1) (first array) (second array)))
+
 (defn version
   [client]
   (-> (-> client
@@ -167,7 +171,7 @@
       (:headers)
       (get "x-influxdb-version")
       (split #"\s")
-      (second)))
+      (get-version)))
 
 (defn sync?
   [client]


### PR DESCRIPTION
This will help later in adding support for v0.9 endpoints by differentiating based on InfluxDb version.