### PR TITLE
Added post-points for influxdb v0.9

### DIFF
--- a/examples/influxdb09/basic.clj
+++ b/examples/influxdb09/basic.clj
@@ -1,0 +1,6 @@
+(require '[capacitor.influxdb09.core :as influx])
+
+(def client
+  (influx/make-client {:db "testdb"}))
+
+(influx/post-points client "cpu,host=webserver01,dc=ny,type=idle value=80")

--- a/src/capacitor/influxdb09/core.clj
+++ b/src/capacitor/influxdb09/core.clj
@@ -1,0 +1,106 @@
+(ns capacitor.influxdb09.core
+  (:require [clj-http.client :as http-client]
+            [clojure.set :as set]
+            [cheshire.core   :as json])
+  (import [java.net URLEncoder]))
+
+;;
+;; ## Client options
+;;
+
+(def default-client
+  "Default HTTP client configuration"
+   { :host              "localhost"
+     :scheme            "http"
+     :port              8086
+     :db                "testdb"
+     :username          "root"
+     :password          "root" })
+
+;;
+;; ## Default write policy options
+;;
+
+(def default-write-options
+  "Default write policy options"
+  { :retention-policy   "default"
+    :precision          "s"
+    :consistency        "all" })
+
+(defn make-client
+  "Returns a map representing an HTTP client configuration.
+
+    Valid options:
+      :host             (default: \"localhost\")
+      :scheme           (default: \"http://\")
+      :port             (default: 8086)
+      :db               (default: \"default-db\")
+      :username         (default \"root\")
+      :password         (default \"root\")
+      :post-opts        (http post options, default: \"nil\")
+      :get-opts         (http get options, default: \"nil\")"
+  [opts]
+  (merge default-client opts))
+
+(defn gen-url-fn
+  "Returns a generated URL according to the operation type."
+  [client action]
+  (str
+    (client :scheme)
+    "://"
+    (client :host)
+    ":"
+    (client :port)
+    (cond
+      (= (action :action) :post-points) (str "/write?"
+                                             "db=" (client :db) "&"
+                                             "rp=" (action :retention-policy) "&"
+                                             "precision=" (action :precision) "&"
+                                             "consistency=" (action :consistency) "&"
+                                             "u=" (client :username) "&"
+                                             "p=" (client :password)))))
+
+(defmulti gen-url-multi
+  (fn [_ action] (class action)))
+
+(defmethod gen-url-multi clojure.lang.Keyword
+  [client action]
+  (gen-url-fn client { :action action }))
+
+(defmethod gen-url-multi clojure.lang.PersistentHashMap
+  [client action]
+  (gen-url-fn client action))
+
+(defmethod gen-url-multi clojure.lang.PersistentArrayMap
+  [client action]
+  (gen-url-fn client action))
+
+(def gen-url
+  (memoize gen-url-multi))
+
+;;
+;; ## Post time-series points
+;;
+
+(defn post-points
+  "Post points to database. Returns HTTP status on success.
+   Uses influxdb's http line protocol to submit data-points"
+  ([client points]
+    (post-points client points { :precision        nil
+                                 :consistency      nil
+                                 :retention-policy nil }))
+  ([client points write-options]
+    (let [url  (gen-url client (merge { :action            :post-points
+                                        :precision         (write-options :precision)
+                                        :consistency       (write-options :consistency)
+                                        :retention-policy  (write-options :retention-policy) }
+                                      default-write-options))
+          body points]
+      ((http-client/post url (merge {
+                                    :body                  body
+                                    :socket-timeout        5000           ;; in milliseconds
+                                    :conn-timeout          5000           ;; in milliseconds
+                                    :content-type          :text
+                                    :throw-entire-message? true } (:post-opts client))) :status ))))
+
+

--- a/test/capacitor/influxdb09/core_test.clj
+++ b/test/capacitor/influxdb09/core_test.clj
@@ -1,0 +1,41 @@
+(ns capacitor.influxdb09.core-test
+  (:require [clojure.test   :refer :all]
+            [capacitor.influxdb09.core :refer :all]))
+
+
+(deftest test-client-00
+  (testing "Default"
+    (is (=
+      {
+        :host     "localhost"
+        :scheme   "http"
+        :port     8086
+        :username "root"
+        :password "root"
+        :db       "testdb"
+      }
+      (make-client {})))))
+
+(deftest test-client-01
+  (testing "Custom"
+    (is (=
+      {
+        :host     "influx.myapp.com"
+        :scheme   "https"
+        :port     443
+        :username "hello"
+        :password "world"
+        :db       "mydb"
+      }
+      (make-client {
+        :host     "influx.myapp.com"
+        :scheme   "https"
+        :port     443
+        :username "hello"
+        :password "world"
+        :db       "mydb" })))))
+
+(deftest test-gen-url-00
+  (testing "post-points"
+    (is (= "http://localhost:8086/write?db=testdb&rp=&precision=&consistency=&u=root&p=root"
+           (gen-url (make-client {}) :post-points)))))


### PR DESCRIPTION
Hello Olivier,
I was looking to integrate v0.9 APIs into existing repo without breaking the existing ones. I thought to create a separate namespace for it. I implemented post-points function just for POC using InfluxDB's new line protocol. I wanted your feedback on it. We can add other endpoints similarly.

Thank you !!