### PR TITLE
Added post-points support for influxdb v0.9

### DIFF
--- a/test/capacitor/core_test.clj
+++ b/test/capacitor/core_test.clj
@@ -21,7 +21,8 @@
         :port     8086
         :username "root"
         :password "root"
-        :db       "default-db"
+        :db       "testdb"
+        :version  "0.8"
       }
       (make-client {})))))
 
@@ -35,6 +36,7 @@
         :username "hello"
         :password "world"
         :db       "my-database-name"
+        :version  "0.8"
       }
       (make-client {
         :host     "influx.myapp.com"
@@ -165,6 +167,11 @@
   (testing "sync"
     (is (= "http://localhost:8086/sync?u=root&p=root"
            (gen-url (make-client {}) :sync)))))
+
+(deftest test-gen-url-20
+  (testing "post-points-again"
+    (is (= "http://localhost:8086/write?db=testdb&rp=&precision=&consistency=&u=root&p=root"
+           (gen-url (make-client {:version "0.9"}) :post-points)))))
 
 (deftest test-format-results-00
   (testing "format-results"


### PR DESCRIPTION
@olauzon Sorry for the big delay !! This commit adds support for `post-points` as per your suggestions. Once you agree with this, I will use the similar way to add support for other operations as well. Since influxdb v0.9 supports all other query at `/query` endpoint, it should be very easy to quickly add all other operations support.

I tested with 0.9 stable version and 0.8.1 version. It worked fine with both of the versions.

With v0.9 one can create a client:

```
(def client
  (influx/make-client {:db "testdb"
                       :host "127.0.0.1"
                       :version "0.9"}))
```

And then push datapoints as:
```
(influx/post-points client "cpu_load_short,host=server01,region=us-west value=0.64 1434055562")
```