### PR TITLE
Added get-query support for influxdb v0.9

### DIFF
--- a/test/capacitor/core_test.clj
+++ b/test/capacitor/core_test.clj
@@ -201,7 +201,7 @@
                 :count 7
               }
             ]
-           (format-results fixture-results-00)))))
+           (format-results (make-client {}) fixture-results-00)))))
 
 (deftest test-make-payload-00
   (testing "format-results" (is (=


### PR DESCRIPTION
Tested it with both v0.8 and v0.9

Here is the sample output :
```
user=> (def client9
  #_=>      (influx/make-client {:db "testdb"
  #_=>                           :host "192.168.59.103"
  #_=>                           :version "0.9"}))
#'user/client9
user=>

user=> (def query-01
  #_=>     (str
  #_=>     "select value from cpu_load_short"))
#'user/query-01
user=> (influx/get-query client9 query-01)
[{:name "cpu_load_short", :value 0.64, :time "2015-06-11T20:46:02Z"} {:name "cpu_load_short", :value 0.64, :time "2015-06-11T20:46:03Z"} {:name "cpu_load_short", :value 0.34, :time "2015-06-11T20:46:09Z"}]
user=>

user=> (def client8
  #_=>      (influx/make-client {:db "testdb"
  #_=>                           :host "192.168.1.25"
  #_=>                           :version "0.8"}))
#'user/client8
user=> (influx/get-query client8 query-01)
[{:name "cpu_load_short", :value 0.34, :sequence_number 30001, :time 1440876477467} {:name "cpu_load_short", :value 0.64, :sequence_number 20001, :time 1440876474100} {:name "cpu_load_short", :value 0.64, :sequence_number 10001, :time 1440876451826}]
``` 