### PR TITLE
Fns to convert points to InfluxDB-0.9 compatible line-protocol

### DIFF
--- a/examples/basic.clj
+++ b/examples/basic.clj
@@ -38,6 +38,9 @@
   {:user "joe"}
   {:user "cannonball"} ])
 
+;;Example for InfluxDB-0.9
+(post-points-line-prot client [["firstSeries" [] ["value" 2 "valueString" "testString"]] ["secondSeries" ["tag" "tagVal" "anotherTag" "anotherTagVal"] ["value" 1] 100]])
+
 (def query
   (str
     "SELECT COUNT(email) "

--- a/src/capacitor/core.clj
+++ b/src/capacitor/core.clj
@@ -845,7 +845,7 @@
 (defn post-points-line-prot
   "Posts points to InfluxDB-0.9. Converts points to InfluxDB line-protocol. Points should be seq of elements. Each element is sequence of key tags fields and optionaly timestamp"
   [client points]
-  (post-points client (points-to-line-prot points)))
+  (post-points-9 client (points-to-line-prot points)))
 
 ;;
 ;; ## Query time-series

--- a/src/capacitor/core.clj
+++ b/src/capacitor/core.clj
@@ -781,10 +781,12 @@
                                     :throw-entire-message? true } (:post-opts client))) :status ))))
 
 (defn escape-key
+  "Keys for series and tags in influx 0.9 need to have spaces and comas escaped"
   [key]
   (-> key (.replace "," "\\,") (.replace " " "\\ ")))
 
 (defn convert-val
+  "Converts value of fields to string value compatible with influx 0.9"
   [val]
   (cond (string? val) (str "\"" (.replace val "\"" "\\\"") "\"")
         (integer? val) (str val "i")
@@ -801,17 +803,18 @@
       (clojure.string/join "," equaled)))
 
 (defn convert-tags-pairs
-  "Converts seq of key-value pairs to influx 0.9 key-value pairs string"
+  "Converts seq of tag key-value pairs to influx 0.9 key-value pairs string"
   [pairs]
   (let [escape-fn (fn [[key val]][(escape-key key) (escape-key val)])]
     (convert-pairs pairs escape-fn)))
 
 (defn convert-fields-pairs
+  "Converts seq of field key-value pairs to influx 0.9 key-value pairs string"
   [pairs]
-  (convert-pairs pairs  escape-field-key-value))
+  (convert-pairs pairs escape-field-key-value))
 
 (defn point-to-line-prot
-  "Converts single point to influxDb-0.9 line protocol. Tags and fields should be a seq of key-value pairs."
+  "Converts single point to influxDb-0.9 line protocol. Tags and fields should be a seq of key-value pairs"
   ([key tags fields]
   (let [key-influx (escape-key key)
         tags-influx (convert-tags-pairs tags)

--- a/src/capacitor/core.clj
+++ b/src/capacitor/core.clj
@@ -1,5 +1,5 @@
 (ns capacitor.core
-  (:use [clojure.string :only [split]])
+  (:use [clojure.string :only [split escape join]])
   (:require [clj-http.client :as http-client]
             [clojure.set :as set]
             [cheshire.core   :as json])
@@ -783,7 +783,7 @@
 (defn escape-key
   "Keys for series and tags in InfluxDB-0.9 need to have spaces and comas escaped"
   [key]
-  (-> key (.replace "," "\\,") (.replace " " "\\ ")))
+ (escape key {\space "\\ " \, "\\,"}))
 
 (defn convert-val
   "Converts value of field to value compatible with InfluxDB-0.9"
@@ -799,8 +799,8 @@
 (defn convert-pairs
   [pairs escape-fn]
     (let [escaped (map escape-fn (partition 2 pairs))
-        equaled (map  #(clojure.string/join "=" %) escaped)]
-      (clojure.string/join "," equaled)))
+        equaled (map  #(join "=" %) escaped)]
+      (join "," equaled)))
 
 (defn convert-tags-pairs
   "Converts seq of tag key-value pairs to InfluxDB-0.9 key-value pairs string"
@@ -829,7 +829,7 @@
                     (if (nil? timestamp)
                       (point-to-line-prot key tags fields)
                       (point-to-line-prot key tags fields (first timestamp))))]
-    (->> points (map convert-fn) (clojure.string/join "\n"))))
+    (->> points (map convert-fn) (join "\n"))))
 
 (defn post-points
   "Post points to database based upon the InfluxDB version"

--- a/src/capacitor/core.clj
+++ b/src/capacitor/core.clj
@@ -791,9 +791,15 @@
         equaled (map  #(clojure.string/join "=" %) escaped)]
     (clojure.string/join "," equaled)))
 
+(defn convert-val
+  [val]
+  (cond (string? val) (str "\"" (.replace val "\"" "\\\"") "\"")
+        (integer? val) (str val "i")
+        :else val))
+
 (defn escape-field-key-value
   [[key val]]
-  [(escape-key key) (str "\"" (.replace val "\"" "\\\"") "\"")])
+  [(escape-key key) (convert-val val)])
 
 (defn convert-fields-pairs
   [pairs]
@@ -801,13 +807,13 @@
         equaled (map  #(clojure.string/join "=" %) escaped)]
     (clojure.string/join "," equaled)))
 
-(defn post-point-9
-  "Post single point to influxDb-0.9. Tags and fields should be a seq of key-value pairs."
-  [client key tags fields]
+(defn point-to-line-prot
+  "Converts single point to influxDb-0.9 line protocol. Tags and fields should be a seq of key-value pairs."
+  [key tags fields]
   (let [key-influx (escape-key key)
         tags-influx (convert-tags-pairs tags)
         fields-influx (convert-fields-pairs fields)]
-    (post-points-9 client (str key-influx "," tags-influx " " fields-influx))))
+    (str key-influx (if (empty? tags-influx) "" (str "," tags-influx)) " " fields-influx)))
 
 (defn post-points
   "Post points to database based upon the InfluxDB version"


### PR DESCRIPTION
Hi,
Because of changes in api between InfluxDB 0.8 and 0.9 capacitor library no longer worked, and I needed to post points to InfluxDB-0.9 fast so I created following fns which allows to post points to InfluxDB-0.9. It isn't the cleanest solution but it may be sufficient for people who migrated to InfluxDB-0.9 and just needs to send data to it.
Currently it depends on arguments passed as seq, but I would like to implement in future other fns which could for example take hash-maps but I would need to know how library users would like to have this map structured.
I think that something like this:
{
:key type:string
:tags type:seq ;;of key-value pairs
:fields type:sed ;;of key-value pairs
} would be sufficient but I would like to hear your opinion on this.